### PR TITLE
Implement GithubRestRepository adapter using HttpClient (DIP)

### DIFF
--- a/src/github/infra/github-rest.repository.ts
+++ b/src/github/infra/github-rest.repository.ts
@@ -1,0 +1,26 @@
+
+import type { IGithubRepository } from '../domain/ports'
+import { GithubUserSchema, GithubRepoSchema, type GithubUser, type GithubRepo } from '../domain/entities'
+import type { HttpClient } from '../../core/http/http';
+
+export class GithubRestRepository implements IGithubRepository {
+  private readonly http: HttpClient;
+
+  constructor(http: HttpClient) {
+    this.http = http;
+  }
+
+  async getUser(username: string): Promise<GithubUser> {
+    const data = await this.http.request(`/users/${encodeURIComponent(username)}`)
+    return GithubUserSchema.parse(data)
+  }
+
+  async listUserRepos(username: string, opts?: { perPage?: number; page?: number; sort?: 'updated' }): Promise<GithubRepo[]> {
+    const params = new URLSearchParams()
+    if (opts?.perPage) params.set('per_page', String(opts.perPage))
+    if (opts?.page) params.set('page', String(opts.page))
+    if (opts?.sort) params.set('sort', opts.sort)
+    const data = await this.http.request(`/users/${encodeURIComponent(username)}/repos?${params.toString()}`)
+    return GithubRepoSchema.array().parse(data)
+  }
+}


### PR DESCRIPTION
## DESCRIPTION
This PR adds the REST infrastructure adapter for the GitHub feature: `GithubRestRepository`.
It implements the `IGithubRepository` port using a generic `HttpClient`, validating responses with Zod.
This keeps the domain decoupled from transport concerns and follows the Dependency Inversion Principle (DIP).

## CHANGES
- **infra**: `GithubRestRepository`
  - `getUser(username)`: `GET /users/:username` → parses with `GithubUserSchema`
  - `listUserRepos(username, { perPage, page, sort })`: `GET /users/:username/repos` with `URLSearchParams` → parses with `GithubRepoSchema.array()`
- Reuses the existing `HttpClient` (timeout + error handling) and Zod domain schemas.