### PR TITLE
Set up DI with React Query and wire GithubRestRepository

### DIFF
--- a/src/app/providers/AppProviders.tsx
+++ b/src/app/providers/AppProviders.tsx
@@ -1,0 +1,20 @@
+/* eslint-disable react-refresh/only-export-components */
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { FetchHttpClient } from '../../core/http/http'
+import { GithubRestRepository } from '../../github/infra/github-rest.repository'
+import { env } from '../../core/env'
+
+
+export const http = new FetchHttpClient(env.VITE_GITHUB_API, env.VITE_REQUEST_TIMEOUT_MS)
+export const githubRepo = new GithubRestRepository(http)
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { staleTime: 1000 * 30, refetchOnWindowFocus: false, retry: 1 },
+  },
+})
+
+export function AppProviders({ children }: { children: React.ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { App } from './App'
+import { AppProviders } from './app/providers/AppProviders'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <AppProviders>
+      <App />
+    </AppProviders>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## DESCRIPTION
This PR introduces the application **composition root** via `AppProviders`, wiring dependency injection (DI) for the HTTP client and the GitHub repository, and enabling React Query globally. It centralizes infrastructure concerns and prepares the UI to consume data through a consistent data-access layer.

## CHANGES
- **Added** `src/app/providers/AppProviders.tsx`:
  - Creates a `QueryClient` with sensible defaults (`staleTime: 30s`, `refetchOnWindowFocus: false`, `retry: 1`).
  - Instantiates `FetchHttpClient` using `env.VITE_GITHUB_API` and `env.VITE_REQUEST_TIMEOUT_MS`.
  - Instantiates `GithubRestRepository` with the `HttpClient`.
  - **Exports** `http` and `githubRepo` singletons for reuse at the composition root.
  - Provides `QueryClientProvider` to the React tree.
- **Updated** `src/main.tsx`:
  - Wraps `<App />` with `<AppProviders>` under `React.StrictMode`.
- **Reused** existing env parsing/validation (Zod) and HTTP client implementation.

## MOTIVATION
Consolidating providers and DI at the application boundary improves maintainability, testability, and adherence to clean architecture. React Query at the root unlocks caching, retries, and background updates without coupling domain/infra to UI concerns.

## HOW TO TEST
- **Manual**:
  1. Run the app and ensure it renders with no provider errors.
  2. Confirm that `QueryClientProvider` is active (e.g., by adding a simple `useQuery` in a test component).
  3. Validate that `GithubRestRepository` uses the configured `HttpClient` (base URL & timeout from `env`).
- **Env sanity**:
  - Defaults exist, but verify your `.env` (e.g., `VITE_GITHUB_API`, `VITE_REQUEST_TIMEOUT_MS`) if overriding.