### PR TITLE
History page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^5.85.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.1",
         "zod": "^4.0.17"
       },
       "devDependencies": {
@@ -18,6 +19,7 @@
         "@testing-library/jest-dom": "^6.7.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^24.3.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@typescript-eslint/eslint-plugin": "^8.40.0",
@@ -1548,6 +1550,15 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.1.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
@@ -2214,6 +2225,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3443,6 +3462,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.1.tgz",
+      "integrity": "sha512-5cy/M8DHcG51/KUIka1nfZ2QeylS4PJRs6TT8I4PF5axVsI5JUxp0hC0NZ/AEEj8Vw7xsEoD7L/6FY+zoYaOGA==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.1.tgz",
+      "integrity": "sha512-NkgBCF3sVgCiAWIlSt89GR2PLaksMpoo3HDCorpRfnCEfdtRPLiuTf+CNXvqZMI5SJLZCLpVCvcZrTdtGW64xQ==",
+      "dependencies": {
+        "react-router": "7.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3574,6 +3629,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3880,6 +3940,12 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-query": "^5.85.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.1",
     "zod": "^4.0.17"
   },
   "devDependencies": {
@@ -21,6 +22,7 @@
     "@testing-library/jest-dom": "^6.7.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^24.3.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@typescript-eslint/eslint-plugin": "^8.40.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,2 +1,23 @@
+import React from 'react'
+import { Routes, Route, Link } from 'react-router-dom'
 import { Home } from './pages/Home'
-export function App() { return <Home /> }
+import { HistoryPage } from './pages/History'
+
+export function App() {
+  return (
+    <div style={{ maxWidth: 1000, margin: '2rem auto', padding: '0 1rem' }}>
+      <header style={{ display: 'flex', gap: 12, alignItems: 'center', marginBottom: 16 }}>
+        <h1 style={{ marginRight: 'auto' }}>GitHub User Explorer</h1>
+        <nav style={{ display: 'flex', gap: 8 }}>
+          <Link to="/">Início</Link>
+          <Link to="/history">Histórico</Link>
+        </nav>
+      </header>
+
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/history" element={<HistoryPage />} />
+      </Routes>
+    </div>
+  )
+}

--- a/src/core/history/history.service.ts
+++ b/src/core/history/history.service.ts
@@ -1,0 +1,45 @@
+import { SearchHistoryEntry } from './history.types'
+
+const KEY = 'gh_user_explorer.history'
+const MAX_ITEMS = 50
+
+function read(): SearchHistoryEntry[] {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return []
+    const arr = JSON.parse(raw) as SearchHistoryEntry[]
+    return Array.isArray(arr) ? arr : []
+  } catch {
+    return []
+  }
+}
+
+function write(items: SearchHistoryEntry[]) {
+  localStorage.setItem(KEY, JSON.stringify(items))
+}
+
+export const HistoryService = {
+  list(): SearchHistoryEntry[] {
+    return read().sort((a, b) => b.at.localeCompare(a.at)) 
+  },
+
+  add(username: string): SearchHistoryEntry {
+    const now = new Date().toISOString()
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2,8)}`
+    const items = read()
+
+
+    const filtered = items.filter(e => e.username.toLowerCase() !== username.toLowerCase())
+    const next = [{ id, username, at: now }, ...filtered].slice(0, MAX_ITEMS)
+
+    write(next)
+    if (!next[0]) {
+      throw new Error('Failed to add history entry')
+    }
+    return next[0]
+  },
+
+  clear() {
+    write([])
+  }
+}

--- a/src/core/history/history.types.ts
+++ b/src/core/history/history.types.ts
@@ -1,0 +1,5 @@
+export type SearchHistoryEntry = {
+  id: string;        
+  username: string;
+  at: string;         
+}

--- a/src/core/history/useSearchHistory.ts
+++ b/src/core/history/useSearchHistory.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useState } from 'react'
+import { HistoryService } from './history.service'
+import type { SearchHistoryEntry } from './history.types'
+
+export function useSearchHistory() {
+  const [items, setItems] = useState<SearchHistoryEntry[]>([])
+
+  const refresh = useCallback(() => {
+    setItems(HistoryService.list())
+  }, [])
+
+  const add = useCallback((username: string) => {
+    HistoryService.add(username)
+    refresh()
+  }, [refresh])
+
+  const clear = useCallback(() => {
+    HistoryService.clear()
+    refresh()
+  }, [refresh])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  return { items, add, clear, refresh }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,14 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { App } from './App'
 import { AppProviders } from './app/providers/AppProviders'
+import { BrowserRouter } from 'react-router-dom'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <AppProviders>
-      <App />
-    </AppProviders>
+    <BrowserRouter>
+      <AppProviders>
+        <App />
+      </AppProviders>
+    </BrowserRouter>
   </React.StrictMode>,
 )

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -1,0 +1,40 @@
+import { useSearchHistory } from '../core/history/useSearchHistory'
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+
+export function HistoryPage() {
+  const { items, clear } = useSearchHistory()
+  const navigate = useNavigate()
+
+  function repeat(username: string) {
+    navigate(`/?q=${encodeURIComponent(username)}`)
+  }
+
+  return (
+    <div>
+      <h2>Histórico de buscas</h2>
+
+      <div style={{ margin: '12px 0 16px' }}>
+        <button onClick={clear} disabled={items.length === 0}>Limpar histórico</button>
+      </div>
+
+      {items.length === 0 ? (
+        <p>Nenhuma busca realizada ainda.</p>
+      ) : (
+        <ul style={{ display: 'grid', gap: 8 }}>
+          {items.map(item => (
+            <li key={item.id} style={{ border: '1px solid #eee', borderRadius: 8, padding: 12, display: 'flex', gap: 12, alignItems: 'center' }}>
+              <div style={{ flex: 1 }}>
+                <div><strong>@{item.username}</strong></div>
+                <div style={{ fontSize: 12, color: '#666' }}>
+                  {new Date(item.at).toLocaleString()}
+                </div>
+              </div>
+              <button onClick={() => repeat(item.username)}>Repetir busca</button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,29 +1,53 @@
-import React, { useState } from 'react'
-import { useGithubRepos, useGithubUser } from '../github/ui/hooks'
-import { UserCard } from '../github/ui/UserCard'
-import { RepoList } from '../github/ui/RepoList'
+
+import { useSearchHistory } from '@/core/history/useSearchHistory'
+import { useGithubRepos, useGithubUser } from '@/github/ui/hooks'
+import { RepoList } from '@/github/ui/RepoList'
+import { UserCard } from '@/github/ui/UserCard'
+import React, { useEffect, useMemo, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 
 export function Home() {
-  const [input, setInput] = useState('')
-  const [username, setUsername] = useState<string | null>('')
+  const location = useLocation()
+  const navigate = useNavigate()
+  const { add: addHistory } = useSearchHistory()
+
+  const initialQ = useMemo(() => {
+    const qs = new URLSearchParams(location.search)
+    return qs.get('q') || 'octocat'
+  }, [location.search])
+
+  const [input, setInput] = useState(initialQ)
+  const [username, setUsername] = useState<string | null>(initialQ)
   const [page, setPage] = useState(1)
 
   const userQ = useGithubUser(username)
   const reposQ = useGithubRepos(username, page, 8)
 
+  useEffect(() => {
+    setInput(initialQ)
+    setUsername(initialQ)
+    setPage(1)
+  }, [initialQ])
+
+  useEffect(() => {
+    if (userQ.data && username) {
+      addHistory(username)
+    }
+  }, [userQ.data, username, addHistory])
+
   function onSubmit(e: React.FormEvent) {
     e.preventDefault()
+    const next = input.trim()
+    if (!next) return
     setPage(1)
-    setUsername(input.trim() || null)
+    navigate(`/?q=${encodeURIComponent(next)}`, { replace: false })
   }
 
   return (
-    <div style={{ maxWidth: 1000, margin: '2rem auto', padding: '0 1rem' }}>
-      <h1>GitHub User Explorer</h1>
-
+    <div>
       <form onSubmit={onSubmit} style={{ display: 'flex', gap: 8, margin: '12px 0 16px' }}>
-        <input value={input} onChange={e => setInput(e.target.value)} placeholder="username (ex: torvalds)" style={{ flex: 1 }} />
+        <input value={input} onChange={(e) => setInput(e.target.value)} placeholder="username (ex: torvalds)" style={{ flex: 1 }} />
         <button type="submit">Buscar</button>
       </form>
 
@@ -38,9 +62,9 @@ export function Home() {
         {reposQ.data && reposQ.data.length > 0 && <RepoList repos={reposQ.data} />}
         {reposQ.data && (
           <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
-            <button disabled={page === 1} onClick={() => setPage(p => Math.max(1, p - 1))}>Anterior</button>
+            <button disabled={page === 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>Anterior</button>
             <span>Página {page}</span>
-            <button disabled={(reposQ.data?.length ?? 0) < 8} onClick={() => setPage(p => p + 1)}>Próxima</button>
+            <button disabled={(reposQ.data?.length ?? 0) < 8} onClick={() => setPage((p) => p + 1)}>Próxima</button>
           </div>
         )}
       </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,16 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "target": "ES2022",
     "lib": ["ES2023", "DOM"],
     "module": "ESNext",
-    "skipLibCheck": true,
     "moduleResolution": "Bundler",
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "jsx": "react-jsx",
-    "types": ["vitest/globals", "@testing-library/jest-dom"],
-    "baseUrl": "src",
-    "paths": { "@/*": ["./*"] }
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,15 @@
 // vite.config.ts
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   plugins: [react()],
+   resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   test: {
     globals: true,          
     environment: 'jsdom',   


### PR DESCRIPTION
# Add Search History Page and related improvements

## Context
This PR introduces the **Search History** feature into the GitHub User Explorer application.  
The goal is to allow users to view their previous searches, click on them to repeat the search, and persist this information locally between sessions.

## Main Changes
- **Router**
  - Added `react-router-dom` and created routes (`/` and `/history`).
  - Implemented a simple header with navigation links.
- **History**
  - Added `HistoryService` with `localStorage` persistence.
  - Implemented `useSearchHistory` hook to expose items/add/clear/refresh in a reactive way.
  - Created `HistoryPage` with:
    - search entries listed in descending order by date/time,
    - a button to clear all history,
    - a button to repeat a search (navigates to Home with `?q=username`).
- **Home**
  - Added support for query parameter `?q=username`.
  - Integrated with history: saves successful searches automatically.
- **Infrastructure**
  - Configured Vite alias `@/` and updated `tsconfig`.
  - Added test setup with Vitest, jsdom, Testing Library, and jest-dom.

## Trade-offs
- Local persistence via `localStorage` is simple but limited to a single device.
- Basic deduplication: keeps only the most recent entry per username.
- History capped at 50 entries to prevent uncontrolled growth.
